### PR TITLE
fix theme color update bugs, normalize HslColor hue, upgrade to net10

### DIFF
--- a/src/Pipboy.Avalonia/HslColor.cs
+++ b/src/Pipboy.Avalonia/HslColor.cs
@@ -20,7 +20,10 @@ public readonly struct HslColor : IEquatable<HslColor>
 
     public HslColor(float h, float s, float l)
     {
-        H = h < 0 ? 0 : h > 360 ? 360 : h;
+        // Normalize H into [0, 360): wrap values ≥ 360 or negative
+        h = h % 360f;
+        if (h < 0f) h += 360f;
+        H = h;
         S = s < 0 ? 0 : s > 1 ? 1 : s;
         L = l < 0 ? 0 : l > 1 ? 1 : l;
     }

--- a/src/Pipboy.Avalonia/Pipboy.Avalonia.csproj
+++ b/src/Pipboy.Avalonia/Pipboy.Avalonia.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Pipboy.Avalonia</RootNamespace>

--- a/src/Pipboy.Avalonia/PipboyTheme.cs
+++ b/src/Pipboy.Avalonia/PipboyTheme.cs
@@ -43,7 +43,7 @@ public partial class PipboyTheme : Styles, IDisposable
     private readonly SolidColorBrush _borderBrush;
     private readonly SolidColorBrush _borderFocusBrush;
 
-    // Semantic status brushes — fixed hues, do not change with primary color
+    // Semantic status brushes — same hue as primary, update with theme changes
     private readonly SolidColorBrush _errorBrush;
     private readonly SolidColorBrush _warningBrush;
     private readonly SolidColorBrush _successBrush;
@@ -139,7 +139,14 @@ public partial class PipboyTheme : Styles, IDisposable
         _selectionBrush.Color = p.Selection;
         _borderBrush.Color = p.Border;
         _borderFocusBrush.Color = p.BorderFocus;
-        // Status brushes are fixed — no update needed
+        _errorBrush.Color   = p.Error;
+        _warningBrush.Color = p.Warning;
+        _successBrush.Color = p.Success;
+
+        // Update raw Color resources
+        Resources["PipboyPrimaryColor"]    = p.Primary;
+        Resources["PipboyBackgroundColor"] = p.Background;
+        Resources["PipboyTextColor"]       = p.Text;
     }
 
     public void Dispose()

--- a/tests/Pipboy.Avalonia.Tests/HslColorTests.cs
+++ b/tests/Pipboy.Avalonia.Tests/HslColorTests.cs
@@ -105,13 +105,19 @@ public class HslColorTests
     }
 
     [Fact]
-    public void Constructor_ClampsHOutOfRange()
+    public void Constructor_NormalizesHIntoRange()
     {
+        // H wraps into [0, 360) — 400 % 360 = 40
         var hsl = new HslColor(400f, 0.5f, 0.5f);
-        Assert.Equal(360f, hsl.H, 1);
+        Assert.Equal(40f, hsl.H, 1);
 
+        // 360 itself wraps to 0
+        var hsl360 = new HslColor(360f, 0.5f, 0.5f);
+        Assert.Equal(0f, hsl360.H, 1);
+
+        // Negative wraps: -10 + 360 = 350
         var hsl2 = new HslColor(-10f, 0.5f, 0.5f);
-        Assert.Equal(0f, hsl2.H, 1);
+        Assert.Equal(350f, hsl2.H, 1);
     }
 
     [Fact]

--- a/tests/Pipboy.Avalonia.Tests/Pipboy.Avalonia.Tests.csproj
+++ b/tests/Pipboy.Avalonia.Tests/Pipboy.Avalonia.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/tests/Pipboy.Avalonia.Tests/PipboyThemeManagerTests.cs
+++ b/tests/Pipboy.Avalonia.Tests/PipboyThemeManagerTests.cs
@@ -48,9 +48,17 @@ public class PipboyThemeManagerTests
         var currentColor = manager.PrimaryColor;
 
         int eventCount = 0;
-        manager.ThemeColorChanged += (_, _) => eventCount++;
-        manager.SetPrimaryColor(currentColor); // same color — should not fire
-        Assert.Equal(0, eventCount);
+        EventHandler<ThemeColorChangedEventArgs> handler = (_, _) => eventCount++;
+        manager.ThemeColorChanged += handler;
+        try
+        {
+            manager.SetPrimaryColor(currentColor); // same color — should not fire
+            Assert.Equal(0, eventCount);
+        }
+        finally
+        {
+            manager.ThemeColorChanged -= handler;
+        }
     }
 
     [Fact]
@@ -61,13 +69,20 @@ public class PipboyThemeManagerTests
 
         int eventCount = 0;
         ThemeColorChangedEventArgs? receivedArgs = null;
-        manager.ThemeColorChanged += (_, e) => { eventCount++; receivedArgs = e; };
-
-        manager.SetPrimaryColor(Colors.Purple);
-        Assert.Equal(1, eventCount);
-        Assert.NotNull(receivedArgs);
-        Assert.Equal(Colors.Purple, receivedArgs.Palette.Primary);
-        manager.ResetToDefault();
+        EventHandler<ThemeColorChangedEventArgs> handler = (_, e) => { eventCount++; receivedArgs = e; };
+        manager.ThemeColorChanged += handler;
+        try
+        {
+            manager.SetPrimaryColor(Colors.Purple);
+            Assert.Equal(1, eventCount);
+            Assert.NotNull(receivedArgs);
+            Assert.Equal(Colors.Purple, receivedArgs.Palette.Primary);
+        }
+        finally
+        {
+            manager.ThemeColorChanged -= handler;
+            manager.ResetToDefault();
+        }
     }
 
     [Fact]
@@ -109,11 +124,18 @@ public class PipboyThemeManagerTests
     {
         var manager = PipboyThemeManager.Instance;
         PipboyColorPalette? receivedPalette = null;
-        manager.ThemeColorChanged += (_, e) => receivedPalette = e.Palette;
-
-        manager.SetPrimaryColor(Colors.Cyan);
-        Assert.NotNull(receivedPalette);
-        Assert.Equal(Colors.Cyan, receivedPalette.Primary);
-        manager.ResetToDefault();
+        EventHandler<ThemeColorChangedEventArgs> handler = (_, e) => receivedPalette = e.Palette;
+        manager.ThemeColorChanged += handler;
+        try
+        {
+            manager.SetPrimaryColor(Colors.Cyan);
+            Assert.NotNull(receivedPalette);
+            Assert.Equal(Colors.Cyan, receivedPalette.Primary);
+        }
+        finally
+        {
+            manager.ThemeColorChanged -= handler;
+            manager.ResetToDefault();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Bug fix**: `PipboyTheme.OnThemeColorChanged` now updates `_errorBrush` / `_warningBrush` / `_successBrush` — these derive from the primary hue in `PipboyColorPalette` but were previously skipped with an incorrect "fixed" comment
- **Bug fix**: `OnThemeColorChanged` now also refreshes `PipboyPrimaryColor` / `PipboyBackgroundColor` / `PipboyTextColor` raw Color resources so `{DynamicResource}` bindings stay in sync after a color change
- **Bug fix**: `HslColor` constructor now wraps H into `[0, 360)` instead of clamping; `H=360` and `H=400` correctly normalize (e.g. 400 → 40, 360 → 0, -10 → 350)
- **Test fix**: `PipboyThemeManagerTests` now uses named handlers with `try/finally` unsubscribe to prevent event handler leaks across singleton test runs
- **Upgrade**: `TargetFramework` updated to `net10.0` for both the library (`Pipboy.Avalonia`) and test projects, consistent with the demo samples

## Test plan

- [ ] All existing unit tests pass (`dotnet test`)
- [ ] Verify runtime color switching updates error/warning/success-styled controls visually
- [ ] Verify `{DynamicResource PipboyPrimaryColor}` bindings update after `SetPrimaryColor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)