### PR TITLE
refactor: split CrtDisplay into partial classes by responsibility

### DIFF
--- a/src/Pipboy.Avalonia/Controls/CrtDisplay.Properties.cs
+++ b/src/Pipboy.Avalonia/Controls/CrtDisplay.Properties.cs
@@ -1,0 +1,244 @@
+using Avalonia;
+using Avalonia.Media;
+
+namespace Pipboy.Avalonia;
+
+public partial class CrtDisplay
+{
+    // ── Scanlines ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>Gets or sets whether horizontal scanlines are rendered.</summary>
+    public static readonly StyledProperty<bool> EnableScanlinesProperty =
+        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableScanlines), defaultValue: true);
+
+    /// <summary>Gets or sets the colour of the scanlines.</summary>
+    public static readonly StyledProperty<Color> ScanlineColorProperty =
+        AvaloniaProperty.Register<CrtDisplay, Color>(nameof(ScanlineColor),
+            defaultValue: Colors.Black);
+
+    /// <summary>Gets or sets the vertical distance between scanlines in logical pixels (minimum 1).</summary>
+    public static readonly StyledProperty<double> ScanlineSpacingProperty =
+        AvaloniaProperty.Register<CrtDisplay, double>(nameof(ScanlineSpacing), defaultValue: 3.0);
+
+    /// <summary>Gets or sets the pen thickness (height) of each scanline in logical pixels (minimum 0.5).</summary>
+    public static readonly StyledProperty<double> ScanlineHeightProperty =
+        AvaloniaProperty.Register<CrtDisplay, double>(nameof(ScanlineHeight), defaultValue: 1.0);
+
+    /// <summary>Gets or sets the opacity of the scanlines (0–1).</summary>
+    public static readonly StyledProperty<double> ScanlineOpacityProperty =
+        AvaloniaProperty.Register<CrtDisplay, double>(nameof(ScanlineOpacity), defaultValue: 0.3);
+
+    /// <summary>Gets or sets whether the scanlines scroll upward (animated CRT refresh sweep).</summary>
+    public static readonly StyledProperty<bool> EnableScanlineAnimationProperty =
+        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableScanlineAnimation), defaultValue: true);
+
+    /// <summary>Gets or sets the scroll speed of the animated scanlines in logical pixels per second.</summary>
+    public static readonly StyledProperty<double> ScanlineAnimSpeedProperty =
+        AvaloniaProperty.Register<CrtDisplay, double>(nameof(ScanlineAnimSpeed), defaultValue: 30.0);
+
+    // ── Scan beam ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>Gets or sets whether the phosphor glow scan beam is rendered.</summary>
+    public static readonly StyledProperty<bool> EnableScanBeamProperty =
+        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableScanBeam), defaultValue: true);
+
+    /// <summary>Gets or sets the colour (including alpha) of the scan beam glow.</summary>
+    public static readonly StyledProperty<Color> ScanBeamColorProperty =
+        AvaloniaProperty.Register<CrtDisplay, Color>(nameof(ScanBeamColor),
+            defaultValue: Color.FromArgb(40, 0, 230, 60));
+
+    /// <summary>Gets or sets the vertical height of the scan beam in logical pixels.</summary>
+    public static readonly StyledProperty<double> ScanBeamHeightProperty =
+        AvaloniaProperty.Register<CrtDisplay, double>(nameof(ScanBeamHeight), defaultValue: 40.0);
+
+    /// <summary>Gets or sets whether the scan beam uses a soft radial gradient (true) or a flat solid colour.</summary>
+    public static readonly StyledProperty<bool> EnableScanBeamGradientProperty =
+        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableScanBeamGradient), defaultValue: true);
+
+    /// <summary>Gets or sets how fast the scan beam travels downward in logical pixels per second.</summary>
+    public static readonly StyledProperty<double> ScanBeamSpeedProperty =
+        AvaloniaProperty.Register<CrtDisplay, double>(nameof(ScanBeamSpeed), defaultValue: 60.0);
+
+    // ── Noise ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Gets or sets whether animated static noise is rendered.</summary>
+    public static readonly StyledProperty<bool> EnableNoiseProperty =
+        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableNoise), defaultValue: true);
+
+    /// <summary>Gets or sets the probability (0–1) that any given pixel cell contains a noise dot.</summary>
+    public static readonly StyledProperty<double> NoiseDensityProperty =
+        AvaloniaProperty.Register<CrtDisplay, double>(nameof(NoiseDensity), defaultValue: 0.02);
+
+    /// <summary>Gets or sets the opacity of the noise dots (0–1).</summary>
+    public static readonly StyledProperty<double> NoiseOpacityProperty =
+        AvaloniaProperty.Register<CrtDisplay, double>(nameof(NoiseOpacity), defaultValue: 0.05);
+
+    /// <summary>Gets or sets the logical pixel size of each noise dot (minimum 1).</summary>
+    public static readonly StyledProperty<int> NoisePixelSizeProperty =
+        AvaloniaProperty.Register<CrtDisplay, int>(nameof(NoisePixelSize), defaultValue: 1);
+
+    /// <summary>Gets or sets the interval in milliseconds between noise refreshes (minimum 16 ms).</summary>
+    public static readonly StyledProperty<int> NoiseRefreshIntervalMsProperty =
+        AvaloniaProperty.Register<CrtDisplay, int>(nameof(NoiseRefreshIntervalMs), defaultValue: 50);
+
+    // ── Vignette ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>Gets or sets whether the radial edge-darkening vignette is applied.</summary>
+    public static readonly StyledProperty<bool> EnableVignetteProperty =
+        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableVignette), defaultValue: true);
+
+    /// <summary>Gets or sets the maximum darkness of the vignette corners (0–1).</summary>
+    public static readonly StyledProperty<double> VignetteIntensityProperty =
+        AvaloniaProperty.Register<CrtDisplay, double>(nameof(VignetteIntensity), defaultValue: 0.35);
+
+    // ── Flicker ───────────────────────────────────────────────────────────────────────
+
+    /// <summary>Gets or sets whether random per-frame brightness dimming (flicker) is applied.</summary>
+    public static readonly StyledProperty<bool> EnableFlickerProperty =
+        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableFlicker), defaultValue: false);
+
+    /// <summary>Gets or sets the maximum fraction of brightness that can be randomly removed each frame (0–1).</summary>
+    public static readonly StyledProperty<double> FlickerIntensityProperty =
+        AvaloniaProperty.Register<CrtDisplay, double>(nameof(FlickerIntensity), defaultValue: 0.04);
+
+    // ── Debug ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Gets or sets whether an FPS counter overlay is shown in the bottom-right corner.</summary>
+    public static readonly StyledProperty<bool> ShowFpsProperty =
+        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(ShowFps), defaultValue: false);
+
+    // ── CLR wrappers ──────────────────────────────────────────────────────────────────
+
+    /// <inheritdoc cref="EnableScanlinesProperty"/>
+    public bool EnableScanlines
+    {
+        get => GetValue(EnableScanlinesProperty);
+        set => SetValue(EnableScanlinesProperty, value);
+    }
+    /// <inheritdoc cref="ScanlineColorProperty"/>
+    public Color ScanlineColor
+    {
+        get => GetValue(ScanlineColorProperty);
+        set => SetValue(ScanlineColorProperty, value);
+    }
+    /// <inheritdoc cref="ScanlineSpacingProperty"/>
+    public double ScanlineSpacing
+    {
+        get => GetValue(ScanlineSpacingProperty);
+        set => SetValue(ScanlineSpacingProperty, value);
+    }
+    /// <inheritdoc cref="ScanlineHeightProperty"/>
+    public double ScanlineHeight
+    {
+        get => GetValue(ScanlineHeightProperty);
+        set => SetValue(ScanlineHeightProperty, value);
+    }
+    /// <inheritdoc cref="ScanlineOpacityProperty"/>
+    public double ScanlineOpacity
+    {
+        get => GetValue(ScanlineOpacityProperty);
+        set => SetValue(ScanlineOpacityProperty, value);
+    }
+    /// <inheritdoc cref="EnableScanlineAnimationProperty"/>
+    public bool EnableScanlineAnimation
+    {
+        get => GetValue(EnableScanlineAnimationProperty);
+        set => SetValue(EnableScanlineAnimationProperty, value);
+    }
+    /// <inheritdoc cref="ScanlineAnimSpeedProperty"/>
+    public double ScanlineAnimSpeed
+    {
+        get => GetValue(ScanlineAnimSpeedProperty);
+        set => SetValue(ScanlineAnimSpeedProperty, value);
+    }
+    /// <inheritdoc cref="EnableScanBeamProperty"/>
+    public bool EnableScanBeam
+    {
+        get => GetValue(EnableScanBeamProperty);
+        set => SetValue(EnableScanBeamProperty, value);
+    }
+    /// <inheritdoc cref="ScanBeamColorProperty"/>
+    public Color ScanBeamColor
+    {
+        get => GetValue(ScanBeamColorProperty);
+        set => SetValue(ScanBeamColorProperty, value);
+    }
+    /// <inheritdoc cref="ScanBeamHeightProperty"/>
+    public double ScanBeamHeight
+    {
+        get => GetValue(ScanBeamHeightProperty);
+        set => SetValue(ScanBeamHeightProperty, value);
+    }
+    /// <inheritdoc cref="EnableScanBeamGradientProperty"/>
+    public bool EnableScanBeamGradient
+    {
+        get => GetValue(EnableScanBeamGradientProperty);
+        set => SetValue(EnableScanBeamGradientProperty, value);
+    }
+    /// <inheritdoc cref="ScanBeamSpeedProperty"/>
+    public double ScanBeamSpeed
+    {
+        get => GetValue(ScanBeamSpeedProperty);
+        set => SetValue(ScanBeamSpeedProperty, value);
+    }
+    /// <inheritdoc cref="EnableNoiseProperty"/>
+    public bool EnableNoise
+    {
+        get => GetValue(EnableNoiseProperty);
+        set => SetValue(EnableNoiseProperty, value);
+    }
+    /// <inheritdoc cref="NoiseDensityProperty"/>
+    public double NoiseDensity
+    {
+        get => GetValue(NoiseDensityProperty);
+        set => SetValue(NoiseDensityProperty, value);
+    }
+    /// <inheritdoc cref="NoiseOpacityProperty"/>
+    public double NoiseOpacity
+    {
+        get => GetValue(NoiseOpacityProperty);
+        set => SetValue(NoiseOpacityProperty, value);
+    }
+    /// <inheritdoc cref="NoisePixelSizeProperty"/>
+    public int NoisePixelSize
+    {
+        get => GetValue(NoisePixelSizeProperty);
+        set => SetValue(NoisePixelSizeProperty, value);
+    }
+    /// <inheritdoc cref="NoiseRefreshIntervalMsProperty"/>
+    public int NoiseRefreshIntervalMs
+    {
+        get => GetValue(NoiseRefreshIntervalMsProperty);
+        set => SetValue(NoiseRefreshIntervalMsProperty, value);
+    }
+    /// <inheritdoc cref="EnableVignetteProperty"/>
+    public bool EnableVignette
+    {
+        get => GetValue(EnableVignetteProperty);
+        set => SetValue(EnableVignetteProperty, value);
+    }
+    /// <inheritdoc cref="VignetteIntensityProperty"/>
+    public double VignetteIntensity
+    {
+        get => GetValue(VignetteIntensityProperty);
+        set => SetValue(VignetteIntensityProperty, value);
+    }
+    /// <inheritdoc cref="EnableFlickerProperty"/>
+    public bool EnableFlicker
+    {
+        get => GetValue(EnableFlickerProperty);
+        set => SetValue(EnableFlickerProperty, value);
+    }
+    /// <inheritdoc cref="FlickerIntensityProperty"/>
+    public double FlickerIntensity
+    {
+        get => GetValue(FlickerIntensityProperty);
+        set => SetValue(FlickerIntensityProperty, value);
+    }
+    /// <inheritdoc cref="ShowFpsProperty"/>
+    public bool ShowFps
+    {
+        get => GetValue(ShowFpsProperty);
+        set => SetValue(ShowFpsProperty, value);
+    }
+}

--- a/src/Pipboy.Avalonia/Controls/CrtDisplay.Rendering.cs
+++ b/src/Pipboy.Avalonia/Controls/CrtDisplay.Rendering.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+
+namespace Pipboy.Avalonia;
+
+public partial class CrtDisplay
+{
+    // ── Effect renderers (called from CrtEffectsLayer.Render) ─────────────────────────
+
+    private void DrawScanlines(DrawingContext context, Rect bounds)
+    {
+        var    pen     = GetScanlinePen();
+        double spacing = Math.Max(1.0, ScanlineSpacing);
+        double startY  = EnableScanlineAnimation ? -_scanlineOffset : 0.0;
+
+        for (double y = startY; y < bounds.Height; y += spacing)
+            context.DrawLine(pen, new Point(0, y), new Point(bounds.Width, y));
+    }
+
+    private void DrawNoise(DrawingContext context)
+    {
+        var dots = _noiseDots;
+        if (dots.Length == 0) return;
+
+        EnsureNoiseBrushes();
+        int pixel = Math.Max(1, NoisePixelSize);
+
+        foreach (var dot in dots)
+            context.DrawRectangle(_noiseBrushes[dot.Brightness], null,
+                new Rect(dot.X, dot.Y, pixel, pixel));
+    }
+
+    private void DrawScanBeam(DrawingContext context, Rect bounds)
+    {
+        double bh    = Math.Max(1.0, ScanBeamHeight);
+        double range = bounds.Height + bh;
+        double beamY = PositiveMod(_sw.Elapsed.TotalSeconds * ScanBeamSpeed, range) - bh;
+
+        if (beamY + bh < 0 || beamY > bounds.Height) return;
+
+        IBrush brush = EnableScanBeamGradient
+            ? GetScanBeamGradientBrush()
+            : GetScanBeamSolidBrush();
+
+        context.DrawRectangle(brush, null, new Rect(0, beamY, bounds.Width, bh));
+    }
+
+    private void DrawVignette(DrawingContext context, Rect bounds)
+        => context.DrawRectangle(GetVignetteBrush(), null, bounds);
+
+    private void DrawFlicker(DrawingContext context, Rect bounds)
+    {
+        EnsureFlickerBrushes();
+        if (_flickerBrushes.Length == 0) return;
+        context.DrawRectangle(_flickerBrushes[_rng.Next(_flickerBrushes.Length)], null, bounds);
+    }
+
+    private void DrawFps(DrawingContext context, Rect bounds)
+    {
+        if (_fpsText is null || _cachedFpsValue != _currentFps)
+        {
+            _cachedFpsValue = _currentFps;
+            _fpsText = new FormattedText(
+                $"FPS: {_currentFps}",
+                CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                new Typeface(new FontFamily("Consolas,Courier New,monospace"),
+                             FontStyle.Normal, FontWeight.Bold, FontStretch.Normal),
+                13,
+                new ImmutableSolidColorBrush(Colors.Lime));
+        }
+
+        double x = bounds.Width  - _fpsText.Width  - 6;
+        double y = bounds.Height - _fpsText.Height - 6;
+        context.DrawRectangle(
+            new ImmutableSolidColorBrush(Color.FromArgb(120, 0, 0, 0)), null,
+            new Rect(x - 3, y - 2, _fpsText.Width + 6, _fpsText.Height + 4));
+        context.DrawText(_fpsText, new Point(x, y));
+    }
+
+    // ── Cache helpers ─────────────────────────────────────────────────────────────────
+
+    private Pen GetScanlinePen()
+    {
+        var    color   = ScanlineColor;
+        double opacity = Math.Clamp(ScanlineOpacity, 0.0, 1.0);
+        double height  = Math.Max(0.5, ScanlineHeight);
+
+        if (_scanlinePen is null
+            || color   != _cachedScanlineColor
+            || Math.Abs(opacity - _cachedScanlineOpacity) > 0.001
+            || Math.Abs(height  - _cachedScanlineHeight)  > 0.001)
+        {
+            _cachedScanlineColor   = color;
+            _cachedScanlineOpacity = opacity;
+            _cachedScanlineHeight  = height;
+            _scanlinePen = new Pen(new ImmutableSolidColorBrush(color, opacity), height);
+        }
+
+        return _scanlinePen;
+    }
+
+    private void EnsureNoiseBrushes()
+    {
+        double opacity = Math.Clamp(NoiseOpacity, 0.0, 1.0);
+        if (Math.Abs(_cachedNoiseAlpha - opacity) <= 0.001) return;
+
+        _cachedNoiseAlpha = opacity;
+        byte alpha = (byte)(opacity * 255);
+        _noiseBrushes = new ImmutableSolidColorBrush[256];
+        for (int i = 0; i < 256; i++)
+            _noiseBrushes[i] = new ImmutableSolidColorBrush(
+                Color.FromArgb(alpha, (byte)i, (byte)i, (byte)i));
+    }
+
+    private ImmutableSolidColorBrush GetScanBeamSolidBrush()
+    {
+        var color = ScanBeamColor;
+        if (_scanBeamSolidBrush is null || color != _cachedScanBeamColor)
+        {
+            _cachedScanBeamColor = color;
+            _scanBeamSolidBrush  = new ImmutableSolidColorBrush(color);
+            _scanBeamBrush       = null; // keep caches in sync
+        }
+        return _scanBeamSolidBrush;
+    }
+
+    private LinearGradientBrush GetScanBeamGradientBrush()
+    {
+        var color = ScanBeamColor;
+        if (_scanBeamBrush is null || color != _cachedScanBeamColor)
+        {
+            _cachedScanBeamColor = color;
+            var transparent = Color.FromArgb(0, color.R, color.G, color.B);
+            _scanBeamBrush = new LinearGradientBrush
+            {
+                StartPoint = new RelativePoint(0.0, 0.0, RelativeUnit.Relative),
+                EndPoint   = new RelativePoint(0.0, 1.0, RelativeUnit.Relative)
+            };
+            _scanBeamBrush.GradientStops.Add(new GradientStop(transparent, 0.00));
+            _scanBeamBrush.GradientStops.Add(new GradientStop(color,       0.30));
+            _scanBeamBrush.GradientStops.Add(new GradientStop(color,       0.70));
+            _scanBeamBrush.GradientStops.Add(new GradientStop(transparent, 1.00));
+        }
+
+        return _scanBeamBrush;
+    }
+
+    private RadialGradientBrush GetVignetteBrush()
+    {
+        double intensity = Math.Clamp(VignetteIntensity, 0.0, 1.0);
+        if (_vignetteBrush is not null && Math.Abs(_cachedVignetteIntensity - intensity) <= 0.001)
+            return _vignetteBrush;
+
+        _cachedVignetteIntensity = intensity;
+        byte alpha = (byte)(intensity * 220);
+        var brush = new RadialGradientBrush
+        {
+            Center         = new RelativePoint(0.5, 0.5, RelativeUnit.Relative),
+            GradientOrigin = new RelativePoint(0.5, 0.5, RelativeUnit.Relative),
+            RadiusX        = new RelativeScalar(0.75, RelativeUnit.Relative),
+            RadiusY        = new RelativeScalar(0.75, RelativeUnit.Relative)
+        };
+        brush.GradientStops.Add(new GradientStop(Color.FromArgb(0,     0, 0, 0), 0.30));
+        brush.GradientStops.Add(new GradientStop(Color.FromArgb(alpha, 0, 0, 0), 1.00));
+        _vignetteBrush = brush;
+        return brush;
+    }
+
+    private void EnsureFlickerBrushes()
+    {
+        double intensity = Math.Clamp(FlickerIntensity, 0.0, 1.0);
+        if (Math.Abs(_cachedFlickerIntensity - intensity) <= 0.001 && _flickerBrushes.Length > 0) return;
+
+        _cachedFlickerIntensity = intensity;
+        _flickerBrushes = new ImmutableSolidColorBrush[FlickerLevels + 1];
+        for (int i = 0; i <= FlickerLevels; i++)
+        {
+            double a = (double)i / FlickerLevels * intensity;
+            _flickerBrushes[i] = new ImmutableSolidColorBrush(
+                Color.FromArgb((byte)(a * 255), 0, 0, 0));
+        }
+    }
+}

--- a/src/Pipboy.Avalonia/Controls/CrtDisplay.cs
+++ b/src/Pipboy.Avalonia/Controls/CrtDisplay.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Specialized;
 using System.Diagnostics;
-using System.Globalization;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
@@ -28,7 +27,7 @@ namespace Pipboy.Avalonia;
 /// Two timers drive animation: a 16 ms animation timer for smooth motion effects (scanlines,
 /// scan beam, flicker, FPS overlay) and a configurable-rate noise timer for static generation.
 /// </remarks>
-public class CrtDisplay : Panel
+public partial class CrtDisplay : Panel
 {
     // ── Overlay layer ─────────────────────────────────────────────────────────────────
     //
@@ -65,243 +64,6 @@ public class CrtDisplay : Panel
 
     private readonly CrtEffectsLayer _overlay;
 
-    // ── Scanlines ─────────────────────────────────────────────────────────────────────
-
-    /// <summary>Gets or sets whether horizontal scanlines are rendered.</summary>
-    public static readonly StyledProperty<bool> EnableScanlinesProperty =
-        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableScanlines), defaultValue: true);
-
-    /// <summary>Gets or sets the colour of the scanlines.</summary>
-    public static readonly StyledProperty<Color> ScanlineColorProperty =
-        AvaloniaProperty.Register<CrtDisplay, Color>(nameof(ScanlineColor),
-            defaultValue: Colors.Black);
-
-    /// <summary>Gets or sets the vertical distance between scanlines in logical pixels (minimum 1).</summary>
-    public static readonly StyledProperty<double> ScanlineSpacingProperty =
-        AvaloniaProperty.Register<CrtDisplay, double>(nameof(ScanlineSpacing), defaultValue: 3.0);
-
-    /// <summary>Gets or sets the pen thickness (height) of each scanline in logical pixels (minimum 0.5).</summary>
-    public static readonly StyledProperty<double> ScanlineHeightProperty =
-        AvaloniaProperty.Register<CrtDisplay, double>(nameof(ScanlineHeight), defaultValue: 1.0);
-
-    /// <summary>Gets or sets the opacity of the scanlines (0–1).</summary>
-    public static readonly StyledProperty<double> ScanlineOpacityProperty =
-        AvaloniaProperty.Register<CrtDisplay, double>(nameof(ScanlineOpacity), defaultValue: 0.3);
-
-    /// <summary>Gets or sets whether the scanlines scroll upward (animated CRT refresh sweep).</summary>
-    public static readonly StyledProperty<bool> EnableScanlineAnimationProperty =
-        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableScanlineAnimation), defaultValue: true);
-
-    /// <summary>Gets or sets the scroll speed of the animated scanlines in logical pixels per second.</summary>
-    public static readonly StyledProperty<double> ScanlineAnimSpeedProperty =
-        AvaloniaProperty.Register<CrtDisplay, double>(nameof(ScanlineAnimSpeed), defaultValue: 30.0);
-
-    // ── Scan beam ─────────────────────────────────────────────────────────────────────
-
-    /// <summary>Gets or sets whether the phosphor glow scan beam is rendered.</summary>
-    public static readonly StyledProperty<bool> EnableScanBeamProperty =
-        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableScanBeam), defaultValue: true);
-
-    /// <summary>Gets or sets the colour (including alpha) of the scan beam glow.</summary>
-    public static readonly StyledProperty<Color> ScanBeamColorProperty =
-        AvaloniaProperty.Register<CrtDisplay, Color>(nameof(ScanBeamColor),
-            defaultValue: Color.FromArgb(40, 0, 230, 60));
-
-    /// <summary>Gets or sets the vertical height of the scan beam in logical pixels.</summary>
-    public static readonly StyledProperty<double> ScanBeamHeightProperty =
-        AvaloniaProperty.Register<CrtDisplay, double>(nameof(ScanBeamHeight), defaultValue: 40.0);
-
-    /// <summary>Gets or sets whether the scan beam uses a soft radial gradient (true) or a flat solid colour.</summary>
-    public static readonly StyledProperty<bool> EnableScanBeamGradientProperty =
-        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableScanBeamGradient), defaultValue: true);
-
-    /// <summary>Gets or sets how fast the scan beam travels downward in logical pixels per second.</summary>
-    public static readonly StyledProperty<double> ScanBeamSpeedProperty =
-        AvaloniaProperty.Register<CrtDisplay, double>(nameof(ScanBeamSpeed), defaultValue: 60.0);
-
-    // ── Noise ─────────────────────────────────────────────────────────────────────────
-
-    /// <summary>Gets or sets whether animated static noise is rendered.</summary>
-    public static readonly StyledProperty<bool> EnableNoiseProperty =
-        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableNoise), defaultValue: true);
-
-    /// <summary>Gets or sets the probability (0–1) that any given pixel cell contains a noise dot.</summary>
-    public static readonly StyledProperty<double> NoiseDensityProperty =
-        AvaloniaProperty.Register<CrtDisplay, double>(nameof(NoiseDensity), defaultValue: 0.02);
-
-    /// <summary>Gets or sets the opacity of the noise dots (0–1).</summary>
-    public static readonly StyledProperty<double> NoiseOpacityProperty =
-        AvaloniaProperty.Register<CrtDisplay, double>(nameof(NoiseOpacity), defaultValue: 0.05);
-
-    /// <summary>Gets or sets the logical pixel size of each noise dot (minimum 1).</summary>
-    public static readonly StyledProperty<int> NoisePixelSizeProperty =
-        AvaloniaProperty.Register<CrtDisplay, int>(nameof(NoisePixelSize), defaultValue: 1);
-
-    /// <summary>Gets or sets the interval in milliseconds between noise refreshes (minimum 16 ms).</summary>
-    public static readonly StyledProperty<int> NoiseRefreshIntervalMsProperty =
-        AvaloniaProperty.Register<CrtDisplay, int>(nameof(NoiseRefreshIntervalMs), defaultValue: 50);
-
-    // ── Vignette ──────────────────────────────────────────────────────────────────────
-
-    /// <summary>Gets or sets whether the radial edge-darkening vignette is applied.</summary>
-    public static readonly StyledProperty<bool> EnableVignetteProperty =
-        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableVignette), defaultValue: true);
-
-    /// <summary>Gets or sets the maximum darkness of the vignette corners (0–1).</summary>
-    public static readonly StyledProperty<double> VignetteIntensityProperty =
-        AvaloniaProperty.Register<CrtDisplay, double>(nameof(VignetteIntensity), defaultValue: 0.35);
-
-    // ── Flicker ───────────────────────────────────────────────────────────────────────
-
-    /// <summary>Gets or sets whether random per-frame brightness dimming (flicker) is applied.</summary>
-    public static readonly StyledProperty<bool> EnableFlickerProperty =
-        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(EnableFlicker), defaultValue: false);
-
-    /// <summary>Gets or sets the maximum fraction of brightness that can be randomly removed each frame (0–1).</summary>
-    public static readonly StyledProperty<double> FlickerIntensityProperty =
-        AvaloniaProperty.Register<CrtDisplay, double>(nameof(FlickerIntensity), defaultValue: 0.04);
-
-    // ── Debug ─────────────────────────────────────────────────────────────────────────
-
-    /// <summary>Gets or sets whether an FPS counter overlay is shown in the bottom-right corner.</summary>
-    public static readonly StyledProperty<bool> ShowFpsProperty =
-        AvaloniaProperty.Register<CrtDisplay, bool>(nameof(ShowFps), defaultValue: false);
-
-    // ── CLR wrappers ──────────────────────────────────────────────────────────────────
-
-    /// <inheritdoc cref="EnableScanlinesProperty"/>
-    public bool EnableScanlines
-    {
-        get => GetValue(EnableScanlinesProperty);
-        set => SetValue(EnableScanlinesProperty, value);
-    }
-    /// <inheritdoc cref="ScanlineColorProperty"/>
-    public Color ScanlineColor
-    {
-        get => GetValue(ScanlineColorProperty);
-        set => SetValue(ScanlineColorProperty, value);
-    }
-    /// <inheritdoc cref="ScanlineSpacingProperty"/>
-    public double ScanlineSpacing
-    {
-        get => GetValue(ScanlineSpacingProperty);
-        set => SetValue(ScanlineSpacingProperty, value);
-    }
-    /// <inheritdoc cref="ScanlineHeightProperty"/>
-    public double ScanlineHeight
-    {
-        get => GetValue(ScanlineHeightProperty);
-        set => SetValue(ScanlineHeightProperty, value);
-    }
-    /// <inheritdoc cref="ScanlineOpacityProperty"/>
-    public double ScanlineOpacity
-    {
-        get => GetValue(ScanlineOpacityProperty);
-        set => SetValue(ScanlineOpacityProperty, value);
-    }
-    /// <inheritdoc cref="EnableScanlineAnimationProperty"/>
-    public bool EnableScanlineAnimation
-    {
-        get => GetValue(EnableScanlineAnimationProperty);
-        set => SetValue(EnableScanlineAnimationProperty, value);
-    }
-    /// <inheritdoc cref="ScanlineAnimSpeedProperty"/>
-    public double ScanlineAnimSpeed
-    {
-        get => GetValue(ScanlineAnimSpeedProperty);
-        set => SetValue(ScanlineAnimSpeedProperty, value);
-    }
-    /// <inheritdoc cref="EnableScanBeamProperty"/>
-    public bool EnableScanBeam
-    {
-        get => GetValue(EnableScanBeamProperty);
-        set => SetValue(EnableScanBeamProperty, value);
-    }
-    /// <inheritdoc cref="ScanBeamColorProperty"/>
-    public Color ScanBeamColor
-    {
-        get => GetValue(ScanBeamColorProperty);
-        set => SetValue(ScanBeamColorProperty, value);
-    }
-    /// <inheritdoc cref="ScanBeamHeightProperty"/>
-    public double ScanBeamHeight
-    {
-        get => GetValue(ScanBeamHeightProperty);
-        set => SetValue(ScanBeamHeightProperty, value);
-    }
-    /// <inheritdoc cref="EnableScanBeamGradientProperty"/>
-    public bool EnableScanBeamGradient
-    {
-        get => GetValue(EnableScanBeamGradientProperty);
-        set => SetValue(EnableScanBeamGradientProperty, value);
-    }
-    /// <inheritdoc cref="ScanBeamSpeedProperty"/>
-    public double ScanBeamSpeed
-    {
-        get => GetValue(ScanBeamSpeedProperty);
-        set => SetValue(ScanBeamSpeedProperty, value);
-    }
-    /// <inheritdoc cref="EnableNoiseProperty"/>
-    public bool EnableNoise
-    {
-        get => GetValue(EnableNoiseProperty);
-        set => SetValue(EnableNoiseProperty, value);
-    }
-    /// <inheritdoc cref="NoiseDensityProperty"/>
-    public double NoiseDensity
-    {
-        get => GetValue(NoiseDensityProperty);
-        set => SetValue(NoiseDensityProperty, value);
-    }
-    /// <inheritdoc cref="NoiseOpacityProperty"/>
-    public double NoiseOpacity
-    {
-        get => GetValue(NoiseOpacityProperty);
-        set => SetValue(NoiseOpacityProperty, value);
-    }
-    /// <inheritdoc cref="NoisePixelSizeProperty"/>
-    public int NoisePixelSize
-    {
-        get => GetValue(NoisePixelSizeProperty);
-        set => SetValue(NoisePixelSizeProperty, value);
-    }
-    /// <inheritdoc cref="NoiseRefreshIntervalMsProperty"/>
-    public int NoiseRefreshIntervalMs
-    {
-        get => GetValue(NoiseRefreshIntervalMsProperty);
-        set => SetValue(NoiseRefreshIntervalMsProperty, value);
-    }
-    /// <inheritdoc cref="EnableVignetteProperty"/>
-    public bool EnableVignette
-    {
-        get => GetValue(EnableVignetteProperty);
-        set => SetValue(EnableVignetteProperty, value);
-    }
-    /// <inheritdoc cref="VignetteIntensityProperty"/>
-    public double VignetteIntensity
-    {
-        get => GetValue(VignetteIntensityProperty);
-        set => SetValue(VignetteIntensityProperty, value);
-    }
-    /// <inheritdoc cref="EnableFlickerProperty"/>
-    public bool EnableFlicker
-    {
-        get => GetValue(EnableFlickerProperty);
-        set => SetValue(EnableFlickerProperty, value);
-    }
-    /// <inheritdoc cref="FlickerIntensityProperty"/>
-    public double FlickerIntensity
-    {
-        get => GetValue(FlickerIntensityProperty);
-        set => SetValue(FlickerIntensityProperty, value);
-    }
-    /// <inheritdoc cref="ShowFpsProperty"/>
-    public bool ShowFps
-    {
-        get => GetValue(ShowFpsProperty);
-        set => SetValue(ShowFpsProperty, value);
-    }
-
     // ── Animation state ───────────────────────────────────────────────────────────────
 
     private readonly Random    _rng = new();
@@ -328,20 +90,20 @@ public class CrtDisplay : Panel
     private double _cachedScanlineOpacity = -1;
     private double _cachedScanlineHeight  = -1;
 
-    private LinearGradientBrush?       _scanBeamBrush;
+    private LinearGradientBrush?      _scanBeamBrush;
     private ImmutableSolidColorBrush? _scanBeamSolidBrush;
-    private Color                      _cachedScanBeamColor = default;
+    private Color                     _cachedScanBeamColor = default;
 
     // When true the scan-beam colour follows the theme automatically.
     // Set to false as soon as the user explicitly assigns ScanBeamColor.
-    private bool _autoScanBeamColor   = true;
-    private bool _updatingFromTheme   = false;
+    private bool _autoScanBeamColor = true;
+    private bool _updatingFromTheme = false;
 
     private RadialGradientBrush? _vignetteBrush;
     private double               _cachedVignetteIntensity = -1;
 
     private const int                  FlickerLevels = 16;
-    private ImmutableSolidColorBrush[] _flickerBrushes     = Array.Empty<ImmutableSolidColorBrush>();
+    private ImmutableSolidColorBrush[] _flickerBrushes        = Array.Empty<ImmutableSolidColorBrush>();
     private double                     _cachedFlickerIntensity = -1;
 
     private FormattedText? _fpsText;
@@ -370,14 +132,18 @@ public class CrtDisplay : Panel
         NoiseDensityProperty  .Changed.AddClassHandler<CrtDisplay>((c, _) => c.RebuildNoise());
         NoisePixelSizeProperty.Changed.AddClassHandler<CrtDisplay>((c, _) => c.RebuildNoise());
 
-        ScanBeamColorProperty         .Changed.AddClassHandler<CrtDisplay>((c, _) =>
+        ScanBeamColorProperty.Changed.AddClassHandler<CrtDisplay>((c, _) =>
         {
             c._scanBeamBrush = null;
             c._scanBeamSolidBrush = null;
             // Any explicit assignment (AXAML, binding, code) disables auto-theme tracking.
             if (!c._updatingFromTheme) c._autoScanBeamColor = false;
         });
-        EnableScanBeamGradientProperty.Changed.AddClassHandler<CrtDisplay>((c, _) => { c._scanBeamBrush = null; c._scanBeamSolidBrush = null; });
+        EnableScanBeamGradientProperty.Changed.AddClassHandler<CrtDisplay>((c, _) =>
+        {
+            c._scanBeamBrush = null;
+            c._scanBeamSolidBrush = null;
+        });
 
         VignetteIntensityProperty.Changed.AddClassHandler<CrtDisplay>((c, _) => c._vignetteBrush = null);
         FlickerIntensityProperty .Changed.AddClassHandler<CrtDisplay>((c, _) => c._cachedFlickerIntensity = -1);
@@ -624,183 +390,6 @@ public class CrtDisplay : Panel
             var trimmed = new NoiseDot[count];
             Array.Copy(buffer, trimmed, count);
             _noiseDots = trimmed;
-        }
-    }
-
-    // ── Effect renderers (called from CrtEffectsLayer.Render) ─────────────────────────
-
-    private void DrawScanlines(DrawingContext context, Rect bounds)
-    {
-        var    pen     = GetScanlinePen();
-        double spacing = Math.Max(1.0, ScanlineSpacing);
-        double startY  = EnableScanlineAnimation ? -_scanlineOffset : 0.0;
-
-        for (double y = startY; y < bounds.Height; y += spacing)
-            context.DrawLine(pen, new Point(0, y), new Point(bounds.Width, y));
-    }
-
-    private void DrawNoise(DrawingContext context)
-    {
-        var dots = _noiseDots;
-        if (dots.Length == 0) return;
-
-        EnsureNoiseBrushes();
-        int pixel = Math.Max(1, NoisePixelSize);
-
-        foreach (var dot in dots)
-            context.DrawRectangle(_noiseBrushes[dot.Brightness], null,
-                new Rect(dot.X, dot.Y, pixel, pixel));
-    }
-
-    private void DrawScanBeam(DrawingContext context, Rect bounds)
-    {
-        double bh    = Math.Max(1.0, ScanBeamHeight);
-        double range = bounds.Height + bh;
-        double beamY = PositiveMod(_sw.Elapsed.TotalSeconds * ScanBeamSpeed, range) - bh;
-
-        if (beamY + bh < 0 || beamY > bounds.Height) return;
-
-        IBrush brush = EnableScanBeamGradient
-            ? GetScanBeamGradientBrush()
-            : GetScanBeamSolidBrush();
-
-        context.DrawRectangle(brush, null, new Rect(0, beamY, bounds.Width, bh));
-    }
-
-    private void DrawVignette(DrawingContext context, Rect bounds)
-        => context.DrawRectangle(GetVignetteBrush(), null, bounds);
-
-    private void DrawFlicker(DrawingContext context, Rect bounds)
-    {
-        EnsureFlickerBrushes();
-        if (_flickerBrushes.Length == 0) return;
-        context.DrawRectangle(_flickerBrushes[_rng.Next(_flickerBrushes.Length)], null, bounds);
-    }
-
-    private void DrawFps(DrawingContext context, Rect bounds)
-    {
-        if (_fpsText is null || _cachedFpsValue != _currentFps)
-        {
-            _cachedFpsValue = _currentFps;
-            _fpsText = new FormattedText(
-                $"FPS: {_currentFps}",
-                CultureInfo.InvariantCulture,
-                FlowDirection.LeftToRight,
-                new Typeface(new FontFamily("Consolas,Courier New,monospace"),
-                             FontStyle.Normal, FontWeight.Bold, FontStretch.Normal),
-                13,
-                new ImmutableSolidColorBrush(Colors.Lime));
-        }
-
-        double x = bounds.Width  - _fpsText.Width  - 6;
-        double y = bounds.Height - _fpsText.Height - 6;
-        context.DrawRectangle(
-            new ImmutableSolidColorBrush(Color.FromArgb(120, 0, 0, 0)), null,
-            new Rect(x - 3, y - 2, _fpsText.Width + 6, _fpsText.Height + 4));
-        context.DrawText(_fpsText, new Point(x, y));
-    }
-
-    // ── Cache helpers ─────────────────────────────────────────────────────────────────
-
-    private Pen GetScanlinePen()
-    {
-        var    color   = ScanlineColor;
-        double opacity = Math.Clamp(ScanlineOpacity, 0.0, 1.0);
-        double height  = Math.Max(0.5, ScanlineHeight);
-
-        if (_scanlinePen is null
-            || color   != _cachedScanlineColor
-            || Math.Abs(opacity - _cachedScanlineOpacity) > 0.001
-            || Math.Abs(height  - _cachedScanlineHeight)  > 0.001)
-        {
-            _cachedScanlineColor   = color;
-            _cachedScanlineOpacity = opacity;
-            _cachedScanlineHeight  = height;
-            _scanlinePen = new Pen(new ImmutableSolidColorBrush(color, opacity), height);
-        }
-
-        return _scanlinePen;
-    }
-
-    private void EnsureNoiseBrushes()
-    {
-        double opacity = Math.Clamp(NoiseOpacity, 0.0, 1.0);
-        if (Math.Abs(_cachedNoiseAlpha - opacity) <= 0.001) return;
-
-        _cachedNoiseAlpha = opacity;
-        byte alpha = (byte)(opacity * 255);
-        _noiseBrushes = new ImmutableSolidColorBrush[256];
-        for (int i = 0; i < 256; i++)
-            _noiseBrushes[i] = new ImmutableSolidColorBrush(
-                Color.FromArgb(alpha, (byte)i, (byte)i, (byte)i));
-    }
-
-    private ImmutableSolidColorBrush GetScanBeamSolidBrush()
-    {
-        var color = ScanBeamColor;
-        if (_scanBeamSolidBrush is null || color != _cachedScanBeamColor)
-        {
-            _cachedScanBeamColor = color;
-            _scanBeamSolidBrush  = new ImmutableSolidColorBrush(color);
-            _scanBeamBrush       = null; // keep caches in sync
-        }
-        return _scanBeamSolidBrush;
-    }
-
-    private LinearGradientBrush GetScanBeamGradientBrush()
-    {
-        var color = ScanBeamColor;
-        if (_scanBeamBrush is null || color != _cachedScanBeamColor)
-        {
-            _cachedScanBeamColor = color;
-            var transparent = Color.FromArgb(0, color.R, color.G, color.B);
-            _scanBeamBrush = new LinearGradientBrush
-            {
-                StartPoint = new RelativePoint(0.0, 0.0, RelativeUnit.Relative),
-                EndPoint   = new RelativePoint(0.0, 1.0, RelativeUnit.Relative)
-            };
-            _scanBeamBrush.GradientStops.Add(new GradientStop(transparent, 0.00));
-            _scanBeamBrush.GradientStops.Add(new GradientStop(color,       0.30));
-            _scanBeamBrush.GradientStops.Add(new GradientStop(color,       0.70));
-            _scanBeamBrush.GradientStops.Add(new GradientStop(transparent, 1.00));
-        }
-
-        return _scanBeamBrush;
-    }
-
-    private RadialGradientBrush GetVignetteBrush()
-    {
-        double intensity = Math.Clamp(VignetteIntensity, 0.0, 1.0);
-        if (_vignetteBrush is not null && Math.Abs(_cachedVignetteIntensity - intensity) <= 0.001)
-            return _vignetteBrush;
-
-        _cachedVignetteIntensity = intensity;
-        byte alpha = (byte)(intensity * 220);
-        var brush = new RadialGradientBrush
-        {
-            Center         = new RelativePoint(0.5, 0.5, RelativeUnit.Relative),
-            GradientOrigin = new RelativePoint(0.5, 0.5, RelativeUnit.Relative),
-            RadiusX        = new RelativeScalar(0.75, RelativeUnit.Relative),
-            RadiusY        = new RelativeScalar(0.75, RelativeUnit.Relative)
-        };
-        brush.GradientStops.Add(new GradientStop(Color.FromArgb(0,     0, 0, 0), 0.30));
-        brush.GradientStops.Add(new GradientStop(Color.FromArgb(alpha, 0, 0, 0), 1.00));
-        _vignetteBrush = brush;
-        return brush;
-    }
-
-    private void EnsureFlickerBrushes()
-    {
-        double intensity = Math.Clamp(FlickerIntensity, 0.0, 1.0);
-        if (Math.Abs(_cachedFlickerIntensity - intensity) <= 0.001 && _flickerBrushes.Length > 0) return;
-
-        _cachedFlickerIntensity = intensity;
-        _flickerBrushes = new ImmutableSolidColorBrush[FlickerLevels + 1];
-        for (int i = 0; i <= FlickerLevels; i++)
-        {
-            double a = (double)i / FlickerLevels * intensity;
-            _flickerBrushes[i] = new ImmutableSolidColorBrush(
-                Color.FromArgb((byte)(a * 255), 0, 0, 0));
         }
     }
 


### PR DESCRIPTION
## Summary

- `CrtDisplay.cs` was a single 819-line file, making it hard to navigate
- Split into three focused `partial class` files with no behaviour changes:
  - **`CrtDisplay.cs`** (~310 lines): core — overlay layer, animation state, constructor, lifecycle, timer management, noise computation, utility
  - **`CrtDisplay.Properties.cs`** (~230 lines): all `StyledProperty` declarations and CLR property wrappers
  - **`CrtDisplay.Rendering.cs`** (~165 lines): all `Draw*` effect methods and brush cache helpers

## Test plan

- [x] Project builds with 0 warnings (`dotnet build`)
- [ ] Existing tests pass
- [ ] Visual output unchanged at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)