### PR TITLE
feat: introduce PipboyControlHeight design token for input controls

### DIFF
--- a/src/Pipboy.Avalonia/PipboyTheme.cs
+++ b/src/Pipboy.Avalonia/PipboyTheme.cs
@@ -109,6 +109,7 @@ public partial class PipboyTheme : Styles, IDisposable
         Resources["PipboyFontSizeLarge"] = 16.0;
 
         // Spacing / sizing design tokens
+        Resources["PipboyControlHeight"]      = 30.0;
         Resources["PipboyTreeViewItemIndent"] = 16.0;
 
         // Load compiled AXAML styles — AvaloniaXamlLoader.Load uses the compiled (NativeAOT-safe)

--- a/src/Pipboy.Avalonia/Styles/Controls/AutoCompleteBox.axaml
+++ b/src/Pipboy.Avalonia/Styles/Controls/AutoCompleteBox.axaml
@@ -6,7 +6,7 @@
             <Setter Property="Foreground" Value="{DynamicResource PipboyTextBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
             <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="MinHeight" Value="30" />
+            <Setter Property="MinHeight" Value="{DynamicResource PipboyControlHeight}" />
             <Setter Property="Padding" Value="8,5" />
             <Setter Property="Template">
                 <ControlTemplate TargetType="AutoCompleteBox">

--- a/src/Pipboy.Avalonia/Styles/Controls/ComboBox.axaml
+++ b/src/Pipboy.Avalonia/Styles/Controls/ComboBox.axaml
@@ -46,7 +46,7 @@
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="CornerRadius" Value="0" />
             <Setter Property="Padding" Value="8,5" />
-            <Setter Property="MinHeight" Value="30" />
+            <Setter Property="MinHeight" Value="{DynamicResource PipboyControlHeight}" />
             <Setter Property="HorizontalContentAlignment" Value="Left" />
             <Setter Property="VerticalContentAlignment" Value="Center" />
             <Setter Property="Cursor" Value="Hand" />

--- a/src/Pipboy.Avalonia/Styles/Controls/NumericUpDown.axaml
+++ b/src/Pipboy.Avalonia/Styles/Controls/NumericUpDown.axaml
@@ -97,7 +97,7 @@
             <Setter Property="Foreground" Value="{DynamicResource PipboyTextBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
             <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="MinHeight" Value="30" />
+            <Setter Property="MinHeight" Value="{DynamicResource PipboyControlHeight}" />
             <Setter Property="Padding" Value="8,5" />
             <Setter Property="Template">
                 <ControlTemplate TargetType="NumericUpDown">

--- a/src/Pipboy.Avalonia/Styles/Controls/TextBox.axaml
+++ b/src/Pipboy.Avalonia/Styles/Controls/TextBox.axaml
@@ -8,7 +8,7 @@
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="CornerRadius" Value="0" />
             <Setter Property="Padding" Value="8,5" />
-            <Setter Property="MinHeight" Value="30" />
+            <Setter Property="MinHeight" Value="{DynamicResource PipboyControlHeight}" />
             <Setter Property="VerticalContentAlignment" Value="Center" />
             <Setter Property="CaretBrush" Value="{DynamicResource PipboyPrimaryBrush}" />
             <Setter Property="SelectionBrush" Value="{DynamicResource PipboySelectionBrush}" />


### PR DESCRIPTION
## Summary

Closes #9

Replaces four identical hardcoded `MinHeight="30"` values across input control styles with a single shared design token `PipboyControlHeight`, consistent with how `PipboyFontSize`, `PipboyFontSizeSmall` and `PipboyFontSizeLarge` are already handled.

### Changes

- **`PipboyTheme.cs`** — add `Resources["PipboyControlHeight"] = 30.0` to the sizing design-token block
- **`TextBox.axaml`** — `MinHeight="{DynamicResource PipboyControlHeight}"`
- **`ComboBox.axaml`** — `MinHeight="{DynamicResource PipboyControlHeight}"`
- **`NumericUpDown.axaml`** — `MinHeight="{DynamicResource PipboyControlHeight}"`
- **`AutoCompleteBox.axaml`** — `MinHeight="{DynamicResource PipboyControlHeight}"`

### Why only these four?

These are the controls with a **standalone `MinHeight` setter** that defines their interactive row height. Other controls (CheckBox, RadioButton, ToggleSwitch, Slider) use size values that are part of their internal visual geometry (indicator box, knob, track), which serve a different purpose and are not the "control height" concept addressed by this token.

### Benefit

Consumers can now adjust the standard input row height application-wide with one resource override instead of patching each control style individually:

```xml
<Application.Resources>
    <x:Double x:Key="PipboyControlHeight">36</x:Double>
</Application.Resources>
```

## Test plan

- [x] `dotnet build` — zero errors, zero warnings
- [ ] TextBox / ComboBox / NumericUpDown / AutoCompleteBox render at the same height as before (30 px minimum)
- [ ] Overriding `PipboyControlHeight` in a consuming app changes all four controls uniformly

🤖 Generated with [Claude Code](https://claude.com/claude-code)