### PR TITLE
Refine rounded controls and progress ring

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   
 A Pip-Boy inspired theme library for Avalonia UI.
 
-Sharp corners, monochromatic phosphor palette, retro terminal aesthetic — drop it in as your sole application theme and every standard control gets the Vault-Tec treatment.
+Softly rounded geometry, a monochromatic phosphor palette, and a retro terminal aesthetic — drop it in as your application theme and every standard control gets the Vault-Tec treatment.
   </p>
 </div>
 
@@ -132,10 +132,10 @@ Use these `CornerRadius` tokens to keep controls and containers visually consist
 
 | Resource Key | Description |
 |---|---|
-| `PipboyCornerRadiusNone` | Square corners for terminal and structural elements |
-| `PipboyCornerRadiusControl` | Subtle rounding for interactive controls |
+| `PipboyCornerRadiusNone` | Optional square-corner override |
+| `PipboyCornerRadiusControl` | Standard rounding for interactive controls |
 | `PipboyCornerRadiusPanel` | Larger rounding for panels and popups |
-| `PipboyCornerRadiusPill` | Fully rounded pill treatment |
+| `PipboyCornerRadiusPill` | Stronger, bounded rounding for compact accents |
 
 ### Border Thickness
 

--- a/samples/Pipboy.Avalonia.Demo/MainWindow.axaml
+++ b/samples/Pipboy.Avalonia.Demo/MainWindow.axaml
@@ -27,7 +27,7 @@
                 Background="{Binding Brush}"
                 Classes="paletteItem"
                 Command="{Binding SelectCommand}"
-                CornerRadius="0"
+                CornerRadius="{DynamicResource PipboyCornerRadiusControl}"
                 Cursor="Hand"
                 ToolTip.Tip="{Binding Hex}">
                 <Button.Styles>
@@ -35,7 +35,7 @@
                         <Setter Property="Width" Value="22" />
                         <Setter Property="Height" Value="22" />
                         <Setter Property="Padding" Value="0" />
-                        <Setter Property="CornerRadius" Value="0" />
+                        <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusControl}" />
                         <Setter Property="BorderThickness" Value="1" />
                         <Setter Property="BorderBrush" Value="Transparent" />
                         <Setter Property="Cursor" Value="Hand" />
@@ -72,7 +72,7 @@
                         Height="14"
                         Background="{Binding CurrentBrush, Mode=TwoWay}"
                         BorderThickness="1"
-                        CornerRadius="0" />
+                        CornerRadius="{DynamicResource PipboyCornerRadiusControl}" />
                     <TextBlock
                         VerticalAlignment="Center"
                         FontSize="10"
@@ -86,7 +86,7 @@
                         <Flyout.FlyoutPresenterTheme>
                             <ControlTheme TargetType="FlyoutPresenter">
                                 <Setter Property="BorderThickness" Value="1" />
-                                <Setter Property="CornerRadius" Value="0" />
+                                <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusPanel}" />
                                 <Setter Property="Padding" Value="10" />
                                 <Setter Property="MinWidth" Value="220" />
                             </ControlTheme>

--- a/samples/Pipboy.Avalonia.Demo/Pages/OverviewPage.axaml
+++ b/samples/Pipboy.Avalonia.Demo/Pages/OverviewPage.axaml
@@ -159,7 +159,7 @@
                                                 <Setter Property="Height" Value="17" />
                                                 <Setter Property="Margin" Value="0,0,4,4" />
                                                 <Setter Property="Cursor" Value="Hand" />
-                                                <Setter Property="CornerRadius" Value="2" />
+                                                <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusControl}" />
                                             </Style>
                                         </WrapPanel.Styles>
                                         <!--  Classic  -->

--- a/samples/Pipboy.Avalonia.Demo/Pages/ProCrtControlPage.axaml
+++ b/samples/Pipboy.Avalonia.Demo/Pages/ProCrtControlPage.axaml
@@ -26,7 +26,7 @@
                 VerticalAlignment="Stretch"
                 Background="Transparent"
                 ClipToBounds="True"
-                CornerRadius="40">
+                CornerRadius="{DynamicResource PipboyCornerRadiusPanel}">
                 <pipboy:ProCrtControl
                     Curvature="{Binding Curvature}"
                     Flicker="{Binding Flicker}"

--- a/samples/Pipboy.Avalonia.Demo/Pages/WindowPage.axaml.cs
+++ b/samples/Pipboy.Avalonia.Demo/Pages/WindowPage.axaml.cs
@@ -81,10 +81,15 @@ public partial class WindowPage : UserControl
         {
             BorderThickness = new Thickness(1.0),
             BorderBrush = new SolidColorBrush(PipboyThemeManager.Instance.PrimaryColor),
-            CornerRadius = new CornerRadius(0.0),
             Child = innerPanel,
             Background = Brushes.Transparent,
         };
+
+        if (this.TryFindResource("PipboyCornerRadiusPanel", null, out var cornerRadius) &&
+            cornerRadius is CornerRadius panelCornerRadius)
+        {
+            innerBorder.CornerRadius = panelCornerRadius;
+        }
 
         window.Content = innerBorder;
         window.Show();

--- a/src/Pipboy.Avalonia.Fx/Styles/PipboyTitleBar.axaml
+++ b/src/Pipboy.Avalonia.Fx/Styles/PipboyTitleBar.axaml
@@ -80,7 +80,7 @@
                                         <Setter Property="Padding" Value="0" />
                                         <Setter Property="Background" Value="Transparent" />
                                         <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessNone}" />
-                                        <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusNone}" />
+                                        <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusControl}" />
                                         <Setter Property="HorizontalContentAlignment" Value="Center" />
                                         <Setter Property="VerticalContentAlignment" Value="Center" />
                                         <Setter Property="FontSize" Value="13" />

--- a/src/Pipboy.Avalonia/PipboyTheme.axaml.cs
+++ b/src/Pipboy.Avalonia/PipboyTheme.axaml.cs
@@ -156,8 +156,8 @@ public partial class PipboyTheme : Styles, IDisposable
 
         Resources["PipboyCornerRadiusNone"] = new CornerRadius(0);
         Resources["PipboyCornerRadiusControl"] = new CornerRadius(3);
-        Resources["PipboyCornerRadiusPanel"] = new CornerRadius(10);
-        Resources["PipboyCornerRadiusPill"] = new CornerRadius(25);
+        Resources["PipboyCornerRadiusPanel"] = new CornerRadius(6);
+        Resources["PipboyCornerRadiusPill"] = new CornerRadius(8);
 
         // Load compiled AXAML styles — AvaloniaXamlLoader.Load uses the compiled (NativeAOT-safe)
         // version generated from PipboyTheme.axaml; the StyleInclude chain inside that AXAML file

--- a/src/Pipboy.Avalonia/ProgressRingGeometryConverter.cs
+++ b/src/Pipboy.Avalonia/ProgressRingGeometryConverter.cs
@@ -1,0 +1,44 @@
+using Avalonia;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using System;
+using System.Globalization;
+
+namespace Pipboy.Avalonia;
+
+public sealed class ProgressRingGeometryConverter : IValueConverter
+{
+    private const double Center = 50;
+    private const double Radius = 42;
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var percentage = value is double number ? Math.Clamp(number, 0, 100) : 0;
+        if (percentage <= 0)
+            return new StreamGeometry();
+
+        // A full 360-degree ArcTo has identical endpoints, so keep the endpoint
+        // fractionally short while remaining visually complete.
+        var sweep = percentage >= 100 ? 359.999 : percentage * 3.6;
+        var start = new Point(Center, Center - Radius);
+        var radians = (sweep - 90) * Math.PI / 180;
+        var end = new Point(
+            Center + Radius * Math.Cos(radians),
+            Center + Radius * Math.Sin(radians));
+
+        var geometry = new StreamGeometry();
+        using var context = geometry.Open();
+        context.BeginFigure(start, false);
+        context.ArcTo(
+            end,
+            new Size(Radius, Radius),
+            0,
+            sweep > 180,
+            SweepDirection.Clockwise);
+        context.EndFigure(false);
+        return geometry;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/src/Pipboy.Avalonia/Styles/AdornerLayer.axaml
+++ b/src/Pipboy.Avalonia/Styles/AdornerLayer.axaml
@@ -7,7 +7,7 @@
                         <Border
                             BorderBrush="{DynamicResource PipboyBorderFocusBrush}"
                             BorderThickness="{DynamicResource PipboyThicknessThin}"
-                            CornerRadius="{DynamicResource PipboyCornerRadiusNone}" />
+                            CornerRadius="{DynamicResource PipboyCornerRadiusControl}" />
                     </FocusAdornerTemplate>
                 </Setter>
             </ControlTheme>

--- a/src/Pipboy.Avalonia/Styles/AutoCompleteBox.axaml
+++ b/src/Pipboy.Avalonia/Styles/AutoCompleteBox.axaml
@@ -37,7 +37,7 @@
                                     Background="{DynamicResource PipboySurfaceBrush}"
                                     BorderBrush="{DynamicResource PipboyBorderBrush}"
                                     BorderThickness="{DynamicResource PipboyThicknessThin}"
-                                    CornerRadius="{DynamicResource PipboyCornerRadiusNone}">
+                                    CornerRadius="{DynamicResource PipboyCornerRadiusPanel}">
                                     <ListBox
                                         Name="PART_SelectingItemsControl"
                                         MaxHeight="{DynamicResource PipboyPopupMaxHeight}"

--- a/src/Pipboy.Avalonia/Styles/Border.axaml
+++ b/src/Pipboy.Avalonia/Styles/Border.axaml
@@ -3,18 +3,21 @@
         <Setter Property="Background" Value="{DynamicResource PipboySurfaceBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusPanel}" />
         <Setter Property="Padding" Value="16" />
     </Style>
     <Style Selector="Border.card-elevated">
         <Setter Property="Background" Value="{DynamicResource PipboySurfaceHighBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource PipboyPrimaryDarkBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusPanel}" />
         <Setter Property="Padding" Value="16" />
     </Style>
     <Style Selector="Border.terminal">
         <Setter Property="Background" Value="{DynamicResource PipboyBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource PipboyPrimaryBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusPanel}" />
         <Setter Property="Padding" Value="12" />
     </Style>
 
@@ -22,6 +25,7 @@
         <Setter Property="Background" Value="{DynamicResource PipboySurfaceBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusControl}" />
         <Setter Property="Padding" Value="8,4" />
     </Style>
 
@@ -29,12 +33,14 @@
         <Setter Property="Background" Value="{DynamicResource PipboySurfaceBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusPanel}" />
     </Style>
 
     <Style Selector="Border.pipboy-panel">
         <Setter Property="Background" Value="{DynamicResource PipboySurfaceHighBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusPanel}" />
         <Setter Property="Padding" Value="8" />
     </Style>
 </Styles>

--- a/src/Pipboy.Avalonia/Styles/ButtonSpinner.axaml
+++ b/src/Pipboy.Avalonia/Styles/ButtonSpinner.axaml
@@ -7,7 +7,7 @@
             TargetType="RepeatButton">
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderBrush" Value="Transparent" />
-            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusNone}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusControl}" />
             <Style Selector="^ /template/ RepeatButton:pointerover">
                 <Setter Property="Background" Value="{DynamicResource PipboySurfaceBrush}" />
                 <Setter Property="BorderBrush" Value="{DynamicResource PipboyHoverBrush}" />

--- a/src/Pipboy.Avalonia/Styles/CheckBox.axaml
+++ b/src/Pipboy.Avalonia/Styles/CheckBox.axaml
@@ -6,7 +6,7 @@
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
             <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
-            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusNone}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusControl}" />
             <Setter Property="Padding" Value="8,0,0,0" />
             <Setter Property="VerticalContentAlignment" Value="Center" />
             <Setter Property="HorizontalAlignment" Value="Left" />
@@ -23,7 +23,8 @@
                             VerticalAlignment="Center"
                             Background="{DynamicResource PipboySurfaceBrush}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}">
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}">
                             <Path
                                 Name="PART_CheckMark"
                                 HorizontalAlignment="Center"

--- a/src/Pipboy.Avalonia/Styles/ContentPage.axaml
+++ b/src/Pipboy.Avalonia/Styles/ContentPage.axaml
@@ -11,7 +11,7 @@
         <ControlTheme x:Key="{x:Type ContentPage}" TargetType="ContentPage">
             <Setter Property="Background" Value="{DynamicResource PipboySurfaceBrush}" />
             <Setter Property="Foreground" Value="{DynamicResource PipboyTextBrush}" />
-            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusNone}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusPanel}" />
             <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
             <Setter Property="Template">
                 <ControlTemplate>

--- a/src/Pipboy.Avalonia/Styles/DropDownButton.axaml
+++ b/src/Pipboy.Avalonia/Styles/DropDownButton.axaml
@@ -11,7 +11,7 @@
             <Setter Property="Foreground" Value="{DynamicResource PipboyTextBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
             <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
-            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusNone}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusControl}" />
             <Setter Property="Padding" Value="14,6" />
             <Setter Property="HorizontalContentAlignment" Value="Center" />
             <Setter Property="VerticalContentAlignment" Value="Center" />

--- a/src/Pipboy.Avalonia/Styles/Expander.axaml
+++ b/src/Pipboy.Avalonia/Styles/Expander.axaml
@@ -5,7 +5,7 @@
                 Width="350"
                 Orientation="Vertical"
                 Spacing="20">
-                <Expander CornerRadius="{DynamicResource PipboyCornerRadiusPill}" ExpandDirection="Up">
+                <Expander CornerRadius="{DynamicResource PipboyCornerRadiusControl}" ExpandDirection="Up">
                     <Expander.Header>
                         <Grid ColumnDefinitions="*, Auto">
                             <TextBlock Grid.Column="0" Text="Expand" />
@@ -17,7 +17,7 @@
                     </StackPanel>
                 </Expander>
                 <Expander
-                    CornerRadius="{DynamicResource PipboyCornerRadiusPill}"
+                    CornerRadius="{DynamicResource PipboyCornerRadiusControl}"
                     ExpandDirection="Down"
                     Header="Expand Down">
                     <StackPanel>
@@ -25,7 +25,7 @@
                     </StackPanel>
                 </Expander>
                 <Expander
-                    CornerRadius="{DynamicResource PipboyCornerRadiusPill}"
+                    CornerRadius="{DynamicResource PipboyCornerRadiusControl}"
                     ExpandDirection="Left"
                     Header="Expand Left">
                     <StackPanel>
@@ -33,7 +33,7 @@
                     </StackPanel>
                 </Expander>
                 <Expander
-                    CornerRadius="{DynamicResource PipboyCornerRadiusPill}"
+                    CornerRadius="{DynamicResource PipboyCornerRadiusControl}"
                     ExpandDirection="Right"
                     Header="Expand Right">
                     <StackPanel>
@@ -58,7 +58,7 @@
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{DynamicResource PipboyCornerRadiusNone}">
+                        CornerRadius="{DynamicResource PipboyCornerRadiusPanel}">
                         <StackPanel>
                             <!--  Header toggle button  -->
                             <ToggleButton

--- a/src/Pipboy.Avalonia/Styles/FlyoutPresenter.axaml
+++ b/src/Pipboy.Avalonia/Styles/FlyoutPresenter.axaml
@@ -16,7 +16,7 @@
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{DynamicResource PipboyCornerRadiusNone}">
+                        CornerRadius="{DynamicResource PipboyCornerRadiusPanel}">
                         <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}" VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}">
                             <ItemsPresenter
                                 Name="PART_ItemsPresenter"
@@ -43,7 +43,7 @@
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{DynamicResource PipboyCornerRadiusNone}">
+                        CornerRadius="{DynamicResource PipboyCornerRadiusPanel}">
                         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
                             <ContentPresenter Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" />
                         </ScrollViewer>

--- a/src/Pipboy.Avalonia/Styles/GridSplitter.axaml
+++ b/src/Pipboy.Avalonia/Styles/GridSplitter.axaml
@@ -10,7 +10,7 @@
                     <Border
                         Name="Root"
                         Background="{TemplateBinding Background}"
-                        CornerRadius="{DynamicResource PipboyCornerRadiusNone}" />
+                        CornerRadius="{DynamicResource PipboyCornerRadiusControl}" />
                 </ControlTemplate>
             </Setter>
 

--- a/src/Pipboy.Avalonia/Styles/GroupBox.axaml
+++ b/src/Pipboy.Avalonia/Styles/GroupBox.axaml
@@ -16,7 +16,7 @@
             <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
             <Setter Property="Foreground" Value="{DynamicResource PipboyBorderBrush}" />
             <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
-            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusNone}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusPanel}" />
             <Setter Property="Template">
                 <ControlTemplate>
                     <Grid

--- a/src/Pipboy.Avalonia/Styles/ListBox.axaml
+++ b/src/Pipboy.Avalonia/Styles/ListBox.axaml
@@ -55,7 +55,7 @@
             <Setter Property="Foreground" Value="{DynamicResource PipboyTextBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
             <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
-            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusNone}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusPanel}" />
             <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
             <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
             <Setter Property="Template">

--- a/src/Pipboy.Avalonia/Styles/NumericUpDown.axaml
+++ b/src/Pipboy.Avalonia/Styles/NumericUpDown.axaml
@@ -44,7 +44,7 @@
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{DynamicResource PipboyCornerRadiusNone}">
+                        CornerRadius="{DynamicResource PipboyCornerRadiusControl}">
                         <Grid ColumnDefinitions="*,20">
                             <!--  Main content (TextBox will go here)  -->
                             <ContentPresenter

--- a/src/Pipboy.Avalonia/Styles/OverlayPopupHost.axaml
+++ b/src/Pipboy.Avalonia/Styles/OverlayPopupHost.axaml
@@ -14,7 +14,7 @@
                                     Background="{DynamicResource PipboyBackgroundBrush}"
                                     BorderBrush="{DynamicResource PipboyBorderBrush}"
                                     BorderThickness="{DynamicResource PipboyThicknessThin}"
-                                    CornerRadius="{DynamicResource PipboyCornerRadiusNone}">
+                                    CornerRadius="{DynamicResource PipboyCornerRadiusPanel}">
                                     <ContentPresenter
                                         Name="PART_ContentPresenter"
                                         Padding="{TemplateBinding Padding}"

--- a/src/Pipboy.Avalonia/Styles/PopupRoot.axaml
+++ b/src/Pipboy.Avalonia/Styles/PopupRoot.axaml
@@ -16,7 +16,7 @@
                                         Background="{DynamicResource PipboyBackgroundBrush}"
                                         BorderBrush="{DynamicResource PipboyBorderBrush}"
                                         BorderThickness="{DynamicResource PipboyThicknessThin}"
-                                        CornerRadius="{DynamicResource PipboyCornerRadiusNone}">
+                                        CornerRadius="{DynamicResource PipboyCornerRadiusPanel}">
                                         <ContentPresenter
                                             Name="PART_ContentPresenter"
                                             Padding="{TemplateBinding Padding}"

--- a/src/Pipboy.Avalonia/Styles/ProgressBar.axaml
+++ b/src/Pipboy.Avalonia/Styles/ProgressBar.axaml
@@ -33,11 +33,12 @@
     <Styles.Resources>
         <converters:StringFormatConverter x:Key="StringFormatConverter" />
         <local:SegmentFillConverter x:Key="SegmentFillConverter" />
+        <local:ProgressRingGeometryConverter x:Key="ProgressRingGeometryConverter" />
         <ControlTheme x:Key="{x:Type ProgressBar}" TargetType="ProgressBar">
             <Setter Property="Foreground" Value="{DynamicResource PipboyPrimaryDarkBrush}" />
             <Setter Property="Background" Value="{DynamicResource PipboySurfaceBrush}" />
             <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
-            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusNone}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusControl}" />
             <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
             <Setter Property="Height" Value="18" />
             <Setter Property="MinHeight" Value="4" />
@@ -206,10 +207,9 @@
         </ControlTheme>
 
         <ControlTheme x:Key="PipboyRingProgressBar" TargetType="ProgressBar">
-            <Setter Property="Foreground" Value="{DynamicResource PipboyPrimaryDarkBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource PipboyPrimaryBrush}" />
             <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource PipboyPrimaryBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
             <Setter Property="Width" Value="100" />
             <Setter Property="Height" Value="100" />
             <Setter Property="Template">
@@ -219,300 +219,53 @@
                         Width="{TemplateBinding Width}"
                         Height="{TemplateBinding Height}">
 
-                        <Viewbox
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Stretch"
-                            Stretch="Fill">
+                        <Viewbox Stretch="Uniform">
                             <Panel Width="100" Height="100">
+                                <Ellipse
+                                    Width="84"
+                                    Height="84"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Stroke="{TemplateBinding BorderBrush}"
+                                    StrokeThickness="5" />
 
-                                <Border
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}" />
-                                <Border
-                                    Margin="13"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}" />
-                                <!--<Canvas>
-                                    <Polyline
-                                        Points="0,15 0,0 15,0"
-                                        Stroke="{TemplateBinding BorderBrush}"
-                                        StrokeThickness="2" />
-                                    <Polyline
-                                        Points="85,0 100,0 100,15"
-                                        Stroke="{TemplateBinding BorderBrush}"
-                                        StrokeThickness="2" />
-                                    <Polyline
-                                        Points="0,85 0,100 15,100"
-                                        Stroke="{TemplateBinding BorderBrush}"
-                                        StrokeThickness="2" />
-                                    <Polyline
-                                        Points="85,100 100,100 100,85"
-                                        Stroke="{TemplateBinding BorderBrush}"
-                                        StrokeThickness="2" />
-                                </Canvas>-->
+                                <Path
+                                    Name="PART_DeterminateRing"
+                                    Data="{Binding Percentage, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource ProgressRingGeometryConverter}}"
+                                    IsVisible="{Binding !IsIndeterminate, RelativeSource={RelativeSource TemplatedParent}}"
+                                    Stroke="{TemplateBinding Foreground}"
+                                    StrokeLineCap="Square"
+                                    StrokeThickness="7" />
 
-                                <Panel Name="PART_IndeterminateRoot" IsVisible="{TemplateBinding IsIndeterminate}">
-                                    <Rectangle
-                                        Width="12"
-                                        Height="12"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Top"
-                                        Fill="{TemplateBinding Foreground}">
-                                        <Rectangle.RenderTransform>
-                                            <TranslateTransform />
-                                        </Rectangle.RenderTransform>
-                                        <Rectangle.Styles>
-                                            <Style Selector="Rectangle">
-                                                <Style.Animations>
-                                                    <Animation
-                                                        Easing="LinearEasing"
-                                                        IterationCount="Infinite"
-                                                        Duration="0:0:2">
-                                                        <KeyFrame KeyTime="0:0:0">
-                                                            <Setter Property="TranslateTransform.X" Value="0" />
-                                                            <Setter Property="TranslateTransform.Y" Value="0" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:0.5">
-                                                            <Setter Property="TranslateTransform.X" Value="88" />
-                                                            <Setter Property="TranslateTransform.Y" Value="0" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:1.0">
-                                                            <Setter Property="TranslateTransform.X" Value="88" />
-                                                            <Setter Property="TranslateTransform.Y" Value="88" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:1.5">
-                                                            <Setter Property="TranslateTransform.X" Value="0" />
-                                                            <Setter Property="TranslateTransform.Y" Value="88" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:2.0">
-                                                            <Setter Property="TranslateTransform.X" Value="0" />
-                                                            <Setter Property="TranslateTransform.Y" Value="0" />
-                                                        </KeyFrame>
-                                                    </Animation>
-                                                </Style.Animations>
-                                            </Style>
-                                        </Rectangle.Styles>
-                                    </Rectangle>
-                                    <Rectangle
-                                        Width="12"
-                                        Height="12"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Top"
-                                        Fill="{TemplateBinding Foreground}"
-                                        Opacity="0.75">
-                                        <Rectangle.RenderTransform>
-                                            <TranslateTransform />
-                                        </Rectangle.RenderTransform>
-                                        <Rectangle.Styles>
-                                            <Style Selector="Rectangle">
-                                                <Style.Animations>
-                                                    <Animation
-                                                        Delay="0:0:0.2"
-                                                        Easing="LinearEasing"
-                                                        IterationCount="Infinite"
-                                                        Duration="0:0:2">
-                                                        <KeyFrame KeyTime="0:0:0">
-                                                            <Setter Property="TranslateTransform.X" Value="0" />
-                                                            <Setter Property="TranslateTransform.Y" Value="0" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:0.5">
-                                                            <Setter Property="TranslateTransform.X" Value="88" />
-                                                            <Setter Property="TranslateTransform.Y" Value="0" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:1.0">
-                                                            <Setter Property="TranslateTransform.X" Value="88" />
-                                                            <Setter Property="TranslateTransform.Y" Value="88" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:1.5">
-                                                            <Setter Property="TranslateTransform.X" Value="0" />
-                                                            <Setter Property="TranslateTransform.Y" Value="88" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:2.0">
-                                                            <Setter Property="TranslateTransform.X" Value="0" />
-                                                            <Setter Property="TranslateTransform.Y" Value="0" />
-                                                        </KeyFrame>
-                                                    </Animation>
-                                                </Style.Animations>
-                                            </Style>
-                                        </Rectangle.Styles>
-                                    </Rectangle>
-
-                                    <Rectangle
-                                        Width="12"
-                                        Height="12"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Top"
-                                        Fill="{TemplateBinding Foreground}"
-                                        Opacity="0.5">
-                                        <Rectangle.RenderTransform>
-                                            <TranslateTransform />
-                                        </Rectangle.RenderTransform>
-                                        <Rectangle.Styles>
-                                            <Style Selector="Rectangle">
-                                                <Style.Animations>
-                                                    <Animation
-                                                        Delay="0:0:0.4"
-                                                        Easing="LinearEasing"
-                                                        IterationCount="Infinite"
-                                                        Duration="0:0:2">
-                                                        <KeyFrame KeyTime="0:0:0">
-                                                            <Setter Property="TranslateTransform.X" Value="0" />
-                                                            <Setter Property="TranslateTransform.Y" Value="0" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:0.5">
-                                                            <Setter Property="TranslateTransform.X" Value="88" />
-                                                            <Setter Property="TranslateTransform.Y" Value="0" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:1.0">
-                                                            <Setter Property="TranslateTransform.X" Value="88" />
-                                                            <Setter Property="TranslateTransform.Y" Value="88" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:1.5">
-                                                            <Setter Property="TranslateTransform.X" Value="0" />
-                                                            <Setter Property="TranslateTransform.Y" Value="88" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:2.0">
-                                                            <Setter Property="TranslateTransform.X" Value="0" />
-                                                            <Setter Property="TranslateTransform.Y" Value="0" />
-                                                        </KeyFrame>
-                                                    </Animation>
-                                                </Style.Animations>
-                                            </Style>
-                                        </Rectangle.Styles>
-                                    </Rectangle>
-                                    <Rectangle
-                                        Width="12"
-                                        Height="12"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Top"
-                                        Fill="{TemplateBinding Foreground}"
-                                        Opacity="0.25">
-                                        <Rectangle.RenderTransform>
-                                            <TranslateTransform />
-                                        </Rectangle.RenderTransform>
-                                        <Rectangle.Styles>
-                                            <Style Selector="Rectangle">
-                                                <Style.Animations>
-                                                    <Animation
-                                                        Delay="0:0:0.6"
-                                                        Easing="LinearEasing"
-                                                        IterationCount="Infinite"
-                                                        Duration="0:0:2">
-                                                        <KeyFrame KeyTime="0:0:0">
-                                                            <Setter Property="TranslateTransform.X" Value="0" />
-                                                            <Setter Property="TranslateTransform.Y" Value="0" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:0.5">
-                                                            <Setter Property="TranslateTransform.X" Value="88" />
-                                                            <Setter Property="TranslateTransform.Y" Value="0" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:1.0">
-                                                            <Setter Property="TranslateTransform.X" Value="88" />
-                                                            <Setter Property="TranslateTransform.Y" Value="88" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:1.5">
-                                                            <Setter Property="TranslateTransform.X" Value="0" />
-                                                            <Setter Property="TranslateTransform.Y" Value="88" />
-                                                        </KeyFrame>
-                                                        <KeyFrame KeyTime="0:0:2.0">
-                                                            <Setter Property="TranslateTransform.X" Value="0" />
-                                                            <Setter Property="TranslateTransform.Y" Value="0" />
-                                                        </KeyFrame>
-                                                    </Animation>
-                                                </Style.Animations>
-                                            </Style>
-                                        </Rectangle.Styles>
-                                    </Rectangle>
-                                </Panel>
-
-                                <Panel Name="PART_DeterminateRoot" IsVisible="{Binding !IsIndeterminate, RelativeSource={RelativeSource TemplatedParent}}">
-                                    <Canvas ClipToBounds="True">
-
-                                        <!--  Top  -->
-                                        <Rectangle
-                                            Canvas.Left="1"
-                                            Canvas.Top="1"
-                                            Height="12"
-                                            Fill="{TemplateBinding Foreground}">
-
-                                            <Rectangle.Width>
-                                                <MultiBinding Converter="{StaticResource SegmentFillConverter}">
-                                                    <Binding Path="Percentage" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                    <Binding Source="Top" />
-                                                    <Binding Path="Bounds.Width" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                    <Binding Path="Bounds.Height" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                </MultiBinding>
-                                            </Rectangle.Width>
-
-                                        </Rectangle>
-
-                                        <!--  Right  -->
-                                        <Rectangle
-                                            Canvas.Top="1"
-                                            Canvas.Right="1"
-                                            Width="12"
-                                            Fill="{TemplateBinding Foreground}">
-
-                                            <Rectangle.Height>
-                                                <MultiBinding Converter="{StaticResource SegmentFillConverter}">
-                                                    <Binding Path="Percentage" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                    <Binding Source="Right" />
-                                                    <Binding Path="Bounds.Width" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                    <Binding Path="Bounds.Height" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                </MultiBinding>
-                                            </Rectangle.Height>
-
-                                        </Rectangle>
-
-                                        <!--  Bottom  -->
-                                        <Rectangle
-                                            Canvas.Right="1"
-                                            Canvas.Bottom="1"
-                                            Height="12"
-                                            Fill="{TemplateBinding Foreground}">
-
-                                            <Rectangle.Width>
-                                                <MultiBinding Converter="{StaticResource SegmentFillConverter}">
-                                                    <Binding Path="Percentage" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                    <Binding Source="Bottom" />
-                                                    <Binding Path="Bounds.Width" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                    <Binding Path="Bounds.Height" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                </MultiBinding>
-                                            </Rectangle.Width>
-
-                                            <Rectangle.RenderTransform>
-                                                <ScaleTransform ScaleX="-1" />
-                                            </Rectangle.RenderTransform>
-
-                                        </Rectangle>
-
-                                        <!--  Left  -->
-                                        <Rectangle
-                                            Canvas.Left="1"
-                                            Canvas.Bottom="1"
-                                            Width="12"
-                                            Fill="{TemplateBinding Foreground}">
-
-                                            <Rectangle.Height>
-                                                <MultiBinding Converter="{StaticResource SegmentFillConverter}">
-                                                    <Binding Path="Percentage" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                    <Binding Source="Left" />
-                                                    <Binding Path="Bounds.Width" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                    <Binding Path="Bounds.Height" RelativeSource="{RelativeSource TemplatedParent}" />
-                                                </MultiBinding>
-                                            </Rectangle.Height>
-
-                                            <Rectangle.RenderTransform>
-                                                <ScaleTransform ScaleY="-1" />
-                                            </Rectangle.RenderTransform>
-
-                                        </Rectangle>
-
-                                    </Canvas>
-                                </Panel>
-
+                                <Path
+                                    Name="PART_IndeterminateRing"
+                                    Data="M 50,8 A 42,42 0 0 1 92,50"
+                                    IsVisible="{TemplateBinding IsIndeterminate}"
+                                    Stroke="{TemplateBinding Foreground}"
+                                    StrokeLineCap="Square"
+                                    StrokeThickness="7"
+                                    RenderTransformOrigin="50%,50%">
+                                    <Path.RenderTransform>
+                                        <RotateTransform />
+                                    </Path.RenderTransform>
+                                    <Path.Styles>
+                                        <Style Selector="Path">
+                                            <Style.Animations>
+                                                <Animation
+                                                    Easing="LinearEasing"
+                                                    IterationCount="Infinite"
+                                                    Duration="0:0:1.15">
+                                                    <KeyFrame KeyTime="0:0:0">
+                                                        <Setter Property="RotateTransform.Angle" Value="0" />
+                                                    </KeyFrame>
+                                                    <KeyFrame KeyTime="0:0:1.15">
+                                                        <Setter Property="RotateTransform.Angle" Value="360" />
+                                                    </KeyFrame>
+                                                </Animation>
+                                            </Style.Animations>
+                                        </Style>
+                                    </Path.Styles>
+                                </Path>
                             </Panel>
                         </Viewbox>
 

--- a/src/Pipboy.Avalonia/Styles/ScrollBar.axaml
+++ b/src/Pipboy.Avalonia/Styles/ScrollBar.axaml
@@ -15,14 +15,14 @@
         <!--  ScrollBar thumb  -->
         <ControlTheme x:Key="PipboyScrollBarThumb" TargetType="Thumb">
             <Setter Property="Background" Value="{DynamicResource PipboyTextDimBrush}" />
-            <Setter Property="MinWidth" Value="8" />
-            <Setter Property="MinHeight" Value="8" />
+            <Setter Property="MinWidth" Value="6" />
+            <Setter Property="MinHeight" Value="6" />
             <Setter Property="Template">
                 <ControlTemplate TargetType="Thumb">
                     <Border
                         Name="ThumbBorder"
                         Background="{TemplateBinding Background}"
-                        CornerRadius="{DynamicResource PipboyCornerRadiusNone}" />
+                        CornerRadius="{DynamicResource PipboyCornerRadiusControl}" />
                 </ControlTemplate>
             </Setter>
             <Style Selector="^:pointerover /template/ Border#ThumbBorder">
@@ -38,7 +38,9 @@
             <Setter Property="Background" Value="{DynamicResource PipboyBackgroundBrush}" />
             <Setter Property="Template">
                 <ControlTemplate TargetType="ScrollBar">
-                    <Border Background="{TemplateBinding Background}">
+                    <Border
+                        Background="{TemplateBinding Background}"
+                        CornerRadius="{DynamicResource PipboyCornerRadiusControl}">
                         <Track
                             Name="PART_Track"
                             Maximum="{TemplateBinding Maximum}"
@@ -63,8 +65,8 @@
 
             <!--  Vertical scrollbar: fixed width, thumb inverted so value 0 = thumb at top  -->
             <Style Selector="^:vertical">
-                <Setter Property="Width" Value="14" />
-                <Setter Property="MinWidth" Value="14" />
+                <Setter Property="Width" Value="8" />
+                <Setter Property="MinWidth" Value="8" />
             </Style>
             <Style Selector="^:vertical /template/ Track">
                 <Setter Property="IsDirectionReversed" Value="True" />
@@ -72,8 +74,8 @@
 
             <!--  Horizontal scrollbar: fixed height  -->
             <Style Selector="^:horizontal">
-                <Setter Property="Height" Value="14" />
-                <Setter Property="MinHeight" Value="14" />
+                <Setter Property="Height" Value="8" />
+                <Setter Property="MinHeight" Value="8" />
             </Style>
 
             <Style Selector="^:disabled">

--- a/src/Pipboy.Avalonia/Styles/Slider.axaml
+++ b/src/Pipboy.Avalonia/Styles/Slider.axaml
@@ -21,7 +21,7 @@
                         Background="{DynamicResource PipboyPrimaryBrush}"
                         BorderBrush="{DynamicResource PipboyBorderFocusBrush}"
                         BorderThickness="{DynamicResource PipboyThicknessThin}"
-                        CornerRadius="{DynamicResource PipboyCornerRadiusNone}" />
+                        CornerRadius="{DynamicResource PipboyCornerRadiusControl}" />
                 </ControlTemplate>
             </Setter>
             <Style Selector="^:pointerover /template/ Border#ThumbBorder">

--- a/src/Pipboy.Avalonia/Styles/SplitButton.axaml
+++ b/src/Pipboy.Avalonia/Styles/SplitButton.axaml
@@ -12,7 +12,7 @@
             <Setter Property="Foreground" Value="{DynamicResource PipboyTextBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
             <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessThin}" />
-            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusNone}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusControl}" />
             <Setter Property="Padding" Value="14,6" />
             <Setter Property="HorizontalContentAlignment" Value="Center" />
             <Setter Property="VerticalContentAlignment" Value="Center" />

--- a/src/Pipboy.Avalonia/Styles/TabControl.axaml
+++ b/src/Pipboy.Avalonia/Styles/TabControl.axaml
@@ -7,7 +7,7 @@
             <Setter Property="BorderBrush" Value="{DynamicResource PipboyBorderBrush}" />
             <Setter Property="BorderThickness" Value="{DynamicResource PipboyThicknessAllButTop}" />
             <Setter Property="Padding" Value="14,6" />
-            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusNone}" />
+            <Setter Property="CornerRadius" Value="{DynamicResource PipboyCornerRadiusPanel}" />
             <Setter Property="Cursor" Value="Hand" />
             <Setter Property="Template">
                 <ControlTemplate TargetType="TabItem">

--- a/src/Pipboy.Avalonia/Styles/TabbedPage.axaml
+++ b/src/Pipboy.Avalonia/Styles/TabbedPage.axaml
@@ -17,11 +17,11 @@
         <x:Double x:Key="TabbedPageTabItemHeaderVerticalPipeHeight">18</x:Double>
         <x:Double x:Key="TabbedPageTabItemHeaderPipeThickness">2</x:Double>
 
-        <CornerRadius x:Key="TabbedPageTabItemHeaderIndicatorCornerRadius">0</CornerRadius>
+        <StaticResource x:Key="TabbedPageTabItemHeaderIndicatorCornerRadius" ResourceKey="PipboyCornerRadiusControl" />
         <Thickness x:Key="TabbedPageTabItemHeaderIndicatorMargin">0</Thickness>
 
         <!--  Tab item sizing & shape  -->
-        <CornerRadius x:Key="TabbedPageTabItemHeaderCornerRadius">0</CornerRadius>
+        <StaticResource x:Key="TabbedPageTabItemHeaderCornerRadius" ResourceKey="PipboyCornerRadiusControl" />
         <Thickness x:Key="TabbedPageTabItemHeaderPadding">12,8</Thickness>
         <Thickness x:Key="TabbedPageTabItemHeaderMargin">0</Thickness>
 
@@ -32,7 +32,7 @@
 
         <!--  Tab strip (bar) styling  -->
         <SolidColorBrush x:Key="TabbedPageTabStripBackground" Color="Transparent" />
-        <CornerRadius x:Key="TabbedPageTabStripCornerRadius">0</CornerRadius>
+        <StaticResource x:Key="TabbedPageTabStripCornerRadius" ResourceKey="PipboyCornerRadiusPanel" />
         <Thickness x:Key="TabbedPageTabStripBorderThickness">0</Thickness>
         <SolidColorBrush x:Key="TabbedPageTabStripBorderBrush" Color="Transparent" />
         <Thickness x:Key="TabbedPageTabStripMargin">0</Thickness>

--- a/src/Pipboy.Avalonia/Styles/ToggleSwitch.axaml
+++ b/src/Pipboy.Avalonia/Styles/ToggleSwitch.axaml
@@ -36,7 +36,7 @@
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{DynamicResource PipboyCornerRadiusNone}">
+                            CornerRadius="{DynamicResource PipboyCornerRadiusControl}">
                             <!--
                                 PART_SwitchKnob must be a Panel subclass (Canvas) so that Avalonia's
                                 ToggleSwitch can call Canvas.SetLeft(PART_MovingKnobs, ...) to slide the knob.
@@ -62,7 +62,7 @@
                                         Height="14"
                                         Margin="1,2"
                                         Background="{DynamicResource PipboyTextDimBrush}"
-                                        CornerRadius="{DynamicResource PipboyCornerRadiusNone}" />
+                                        CornerRadius="{DynamicResource PipboyCornerRadiusControl}" />
                                 </Panel>
                             </Canvas>
                         </Border>

--- a/src/Pipboy.Avalonia/Styles/ToolTip.axaml
+++ b/src/Pipboy.Avalonia/Styles/ToolTip.axaml
@@ -16,7 +16,7 @@
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{DynamicResource PipboyCornerRadiusNone}">
+                        CornerRadius="{DynamicResource PipboyCornerRadiusControl}">
                         <ContentPresenter Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" />
                     </Border>
                 </ControlTemplate>


### PR DESCRIPTION
## Summary
- centralize and rebalance corner-radius tokens for restrained rounding
- apply rounded geometry consistently across controls, popups, panels, and the demo
- slim and soften scrollbar styling
- replace the square progress-ring implementation with a circular determinate/indeterminate ring
- bind the CheckBox template border to its CornerRadius
- update the README design-token description

## Validation
- Desktop demo and AXAML compiled successfully before the running demo locked its output assemblies
- 167 tests passed